### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,5 @@ kairos.detect(image, subject_id, gallery_name, callback);
 
 ##Support 
 Have an issue? Visit our [Support page](http://www.kairos.com/support) or [create an issue on GitHub](https://github.com/kairosinc/Kairos-SDK-Javascript)
+
+Test on [RapidAPI](https://rapidapi.com/package/KairosAPI/functions?utm_source=KairosGitHub&utm_medium=button)


### PR DESCRIPTION
I've added a link in your README to Kairos's functions page in RapidAPI. I've done this for a few Kairos SDKs to help those who are reading the READMEs, understand and test the API before use.